### PR TITLE
Changes for datetime representation  Unresolved comment '# TODO: replace unix time in ms with datetime'.

### DIFF
--- a/sklbench/runner/commands_helper.py
+++ b/sklbench/runner/commands_helper.py
@@ -18,6 +18,7 @@ import json
 import os
 import sys
 from time import time
+from datetime import datetime
 from typing import Dict, List, Tuple
 
 from ..utils.bench_case import get_bench_case_name, get_bench_case_value
@@ -61,7 +62,7 @@ def generate_benchmark_command(
                         get_bench_case_name(bench_case, shortened=True, separator="_"),
                         hash_from_json_repr(bench_case),
                         # TODO: replace unix time in ms with datetime
-                        str(int(time() * 1000)),
+                        datetime.now().strftime("%Y-%m-%d %H:%M"),
                     ]
                 ),
             )


### PR DESCRIPTION
Fix for [sklbench\runner\commands_helper.py:63]
Replaced str(int(time() * 1000)) to 
>>> datetime.now().strftime("%Y-%m-%d %H:%M")
'2025-03-07 10:42'

so as to represent time in year-month-date hour:minute format for easy readability

## Description

_Add a comprehensive description of proposed changes_

_List associated issue number(s) if exist(s): #6 (for example)_

_Documentation PR (if needed): #1340 (for example)_

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [X] I have reviewed my changes thoroughly before submitting this pull request.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [ ] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [ ] I have added a respective label(s) to PR if I have a permission for that.
- [ ] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [X] I have run it locally and tested the changes extensively.
- [ ] All CI jobs are green or I have provided justification why they aren't.
- [ ] I have extended testing suite if new functionality was introduced in this PR.
